### PR TITLE
Require lodash 4.17 for AsyncFunction recognition

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:style": "./scripts/test:style"
   },
   "dependencies": {
-    "lodash": "^4.0.0"
+    "lodash": "^4.17.0"
   },
   "devDependencies": {
     "tslint": "^3.13.0",


### PR DESCRIPTION
[This line](https://github.com/lodash/lodash/blob/b1ff59b3ea86aefb67676e4e3f5ff636c23fd6c7/isFunction.js#L5) isn't in (one of the versions of) 4.16